### PR TITLE
Create mod configuration file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 **Version Information**
-AUI Mod version: 
+AUI Mod version:
 Space Warp Mod version:
-KSP 2 version: (current version is 0.1.0.0.20892)
+KSP 2 version: (current version is 0.1.1.0.21572)
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,14 +5,10 @@
   "tasks": [
     {
       "label": "build",
-      "command": "dotnet",
-      "type": "shell",
+      "command": "python",
+      "type": "process",
       "args": [
-        "build",
-        // Ask dotnet build to generate full paths for file names.
-        "/property:GenerateFullPaths=true",
-        // Do not generate summary otherwise it leads to duplicate errors in Problems panel
-        "/consoleloggerparameters:NoSummary"
+        "${workspaceFolder}/build_scripts/build.py"
       ],
       "group": "build",
       "presentation": {

--- a/alternative_ui/AUIConfigurationSettings.cs
+++ b/alternative_ui/AUIConfigurationSettings.cs
@@ -1,6 +1,5 @@
 using BepInEx.Configuration;
 using KSP.Game;
-using System;
 
 namespace AUI
 {
@@ -47,71 +46,6 @@ namespace AUI
         private T _value;
     }
 
-    /// <summary>Represents basic info for a ConfigEntry.</summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class ConfigEntryInfoAttribute<T> : Attribute
-    {
-        public string Section;
-        public string Key;
-        public T Value;
-        public string Description;
-        public ConfigEntryInfoAttribute(string section, string key, T value)
-        {
-            Section = section;
-            Key = key;
-            Value = value;
-            Description = "";
-        }
-    }
-
-    // TODO Create an interface that has a common method to get an AcceptableValueBase from both types of attributes.
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = true)]
-    public abstract class AcceptableValueAttribute : Attribute
-    {
-        public abstract AcceptableValueBase GetAcceptableValues();
-    }
-
-    public class AcceptableConfigRangeAttribute<T> : AcceptableValueAttribute where T : IComparable
-    {
-        private AcceptableValueRange<T> _range;
-
-        public AcceptableConfigRangeAttribute(T min, T max)
-        {
-            _range = new AcceptableValueRange<T>(min, max);
-        }
-
-        public override AcceptableValueBase GetAcceptableValues()
-        {
-            return _range;
-        }
-    }
-
-    public class AcceptableConfigListAttribute<T> : AcceptableValueAttribute where T : IEquatable<T>
-    {
-        private AcceptableValueList<T> _list;
-
-        public AcceptableConfigListAttribute(params T[] acceptableValues)
-        {
-            _list = new AcceptableValueList<T>(acceptableValues);
-        }
-
-        public override AcceptableValueBase GetAcceptableValues()
-        {
-            return _list;
-        }
-    }
-
-    [Serializable]
-    public class InvalidConfigurationAttributesException : Exception
-    {
-        public InvalidConfigurationAttributesException() { }
-        public InvalidConfigurationAttributesException(string message) : base(message) { }
-        public InvalidConfigurationAttributesException(string message, Exception inner) : base(message, inner) { }
-        protected InvalidConfigurationAttributesException(
-            System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
-
     public class AUIConfigurationSettings : KerbalMonoBehaviour
     {
         public ConfigFile PluginConfig;
@@ -133,119 +67,28 @@ namespace AUI
             superEntry.BindMe(PluginConfig);
         }
 
-        // public void AddEntryWithAttribute<T>(SuperEntry<T> superEntry)
-        // {
-        //     Logger.LogError($"AddEntryWithAttribute: Start ({superEntry.ToString()})");
-        //     // Attribute[] attributes = Attribute.GetCustomAttributes(superEntry.GetType());
-        //     ConfigEntryInfoAttribute<T>[] attributes = (ConfigEntryInfoAttribute<T>[])superEntry.GetType().GetCustomAttributes(typeof(ConfigEntryInfoAttribute<T>), false);
-        //     Logger.LogWarning($"AddEntryWithAttribute: Num ConfigEntryInfo Attributes: {attributes.Count()}");
-
-        //     ConfigEntryInfoAttribute<T> entryInfo = null;
-        //     AcceptableValueBase acceptableValues = null;
-
-        //     foreach (Attribute attr in attributes)
-        //     {
-        //         Logger.LogWarning($"AddEntryWithAttribute:   Attribute ({attr})");
-        //         if (attr is ConfigEntryInfoAttribute<T>)
-        //         {
-        //             if (entryInfo == null)
-        //             {
-        //                 entryInfo = attr as ConfigEntryInfoAttribute<T>;
-        //                 Logger.LogInfo($"AddEntryWithAttribute:     attribute is ConfigEntryInfoAttribute ({entryInfo})");
-        //             }
-        //             else
-        //             {
-        //                 throw new InvalidConfigurationAttributesException("Multiple ConfigEntryInfo attributes detected. Only one ConfigEntryInfo attribute is allowed per ConfigEntry.");
-        //             }
-        //         }
-
-        //         if (attr is AcceptableValueAttribute)
-        //         {
-        //             if (acceptableValues == null)
-        //             {
-        //                 acceptableValues = (attr as AcceptableValueAttribute).GetAcceptableValues();
-        //                 Logger.LogInfo($"AddEntryWithAttribute:     attribute is AcceptableValueAttribute ({acceptableValues})");
-        //             }
-        //             else
-        //             {
-        //                 throw new InvalidConfigurationAttributesException("Multiple AcceptableValue attributes detected. Only one AcceptableValue attribute is allowed per ConfigEntry.");
-        //             }
-        //         }
-        //     }
-
-        //     if (entryInfo == null)
-        //     {
-        //         if (acceptableValues != null)
-        //         {
-        //             throw new InvalidConfigurationAttributesException("Detected a AcceptableValue attribute without a ConfigEntryInfo attribute. A ConfigEntryInfo attribute is required in order to use an AcceptableValue attribute.");
-        //         }
-        //         else
-        //         {
-        //             // No config-related attribute found. This entry must be manually bound later.
-        //             Logger.LogWarning($"AddEntryWithAttribute<T>: Was provided with a ConfigEntry item without a ConfigEntryInfo attribute set! Make sure that this is intentional and that the ConfigEntry item will be bound to the ConfigFile at a later point! {superEntry.ToString()}");
-        //         }
-        //     }
-        //     else
-        //     {
-        //         // A config info attribute is attached to this entry. Automatically bind it to the config file.
-        //         ConfigDefinition entryDef = new ConfigDefinition(entryInfo.Section, entryInfo.Key);
-        //         ConfigDescription entryDesc = new ConfigDescription(entryInfo.Description, acceptableValues);
-        //         superEntry.Entry = PluginConfig.Bind(entryDef, entryInfo.Value, entryDesc);
-        //         Logger.LogInfo($"AddEntryWithAttribute:     Binding to config file ({superEntry.Entry})");
-        //     }
-        //     Logger.LogWarning($"AddEntryWithAttribute: End");
-        // }
-
         public void SetUpConfig()
         {
             Logger.LogInfo("Setting up AUI configuration settings.");
-            // _enableOABPartsPickerCollapseToggle = PluginConfig.Bind(
-            //     _OABSectionString,  // Section name
-            //     "Enable toggle button to collapse the parts picker drawer",  // Configuration key
-            //     true,  // Default value
-            //     "A toggle button is added that will expand and collapse the parts picker drawer.");  // Description
-            // Logger.LogDebug(_enableOABPartsPickerCollapseToggle.Value);
 
-            // _enableOABCenterToolbarsOnPartsPickerCollapse = PluginConfig.Bind(
-            //     _OABSectionString,  // Section name
-            //     "TestHeader",  // Configuration key
-            //     true,  // Default value
-            //     "This is just a test config option.");  // Description
-            // Logger.LogDebug(_enableOABCenterToolbarsOnPartsPickerCollapse.Value);
             AddSuperEntry(_enableOABPartsPickerCollapseToggle);
             AddSuperEntry(_enableOABCenterToolbarsOnPartsPickerCollapse);
-            AddSuperEntry(_exampleTestStringList);
+            // AddSuperEntry(_exampleTestStringList);
         }
 
         const string _OABSectionString = "Vehicle Assembly Building (VAB/OAB)";
-        [ConfigEntryInfo<bool>(
-            _OABSectionString,
-            "Enable toggle button to collapse the parts picker drawer",
-            true,
-            Description = "A toggle button is added that will expand and collapse the parts picker drawer.")]
         private SuperEntry<bool> _enableOABPartsPickerCollapseToggle = new SuperEntry<bool>(
             _OABSectionString,
-            "Enable toggle button to collapse the parts picker drawer",
+            "Collapsable Parts Picker Button",
             true,
             "A toggle button is added that will expand and collapse the parts picker drawer.");
 
-        [ConfigEntryInfo<bool>(
-            _OABSectionString,
-            "Keep vehicle toolbars centered in work area when parts picker drawer is collapsed",
-            true,
-            Description = "When the parts picker drawer is collapsed, this setting will automatically position the vehicle editing toolbars in the center of the working area.")]
         private SuperEntry<bool> _enableOABCenterToolbarsOnPartsPickerCollapse = new SuperEntry<bool>(
             _OABSectionString,
-            "Keep vehicle toolbars centered in work area when parts picker drawer is collapsed",
+            "Auto-center Editor Toolbars When Parts Picker Collapses",
             true,
-            "When the parts picker drawer is collapsed, this setting will automatically position the vehicle editing toolbars in the center of the working area.");
+            "When the parts picker drawer is collapsed, this setting will automatically position the vehicle editing toolbars in the center of the working area. If disabled, the toolbars will remain fixed in place.");
 
-        [ConfigEntryInfo<string>(
-            "Debug Settings",
-            "Tests a list of string options",
-            "Default",
-            Description = "This hopefully has a list of available string values.")]
-        [AcceptableConfigList<string>("Default", "First", "Second", "Third")]
         public SuperEntry<string> _exampleTestStringList = new SuperEntry<string>(
             "Debug Settings",
             "Tests a list of string options",

--- a/alternative_ui/AUIConfigurationSettings.cs
+++ b/alternative_ui/AUIConfigurationSettings.cs
@@ -1,0 +1,157 @@
+using BepInEx.Configuration;
+using KSP.Game;
+
+namespace AUI
+{
+    /// <summary>Represents basic info for a ConfigEntry.</summary>
+    public class ConfigEntryInfoAttribute<T> : System.Attribute
+    {
+        public string Section;
+        public string Key;
+        public T Value;
+        public string Description;
+        public ConfigEntryInfoAttribute(string section, string key, T value)
+        {
+            Section = section;
+            Key = key;
+            Value = value;
+            Description = "";
+        }
+    }
+
+    // TODO Create an interface that has a common method to get an AcceptableValueBase from both types of attributes.
+    public class AcceptableConfigRangeAttribute<T> : System.Attribute where T : System.IComparable
+    {
+        private AcceptableValueRange<T> _range;
+        public AcceptableConfigRangeAttribute(T min, T max)
+        {
+            _range = new AcceptableValueRange<T>(min, max);
+        }
+
+        public AcceptableValueRange<T> GetRange()
+        {
+            return _range;
+        }
+    }
+
+    public class AcceptableConfigListAttribute<T> : System.Attribute where T : System.IEquatable<T>
+    {
+        private AcceptableValueList<T> _list;
+        public AcceptableConfigListAttribute(params T[] acceptableValues)
+        {
+            _list = new AcceptableValueList<T>(acceptableValues);
+        }
+
+        public AcceptableValueList<T> GetList()
+        {
+            return _list;
+        }
+    }
+
+    public class AUIConfigurationSettings : KerbalMonoBehaviour
+    {
+        public ConfigFile PluginConfig;
+        public BepInEx.Logging.ManualLogSource Logger;
+        public bool OABPartsPickerCollapseToggleIsEnabled
+        {
+            get => _enableOABPartsPickerCollapseToggle.Value;
+            set => _enableOABPartsPickerCollapseToggle.Value = value;
+        }
+
+        public bool OABCenterToolbarsOnPartsPickerCollapseIsEnabled
+        {
+            get => _enableOABCenterToolbarsOnPartsPickerCollapse.Value;
+            set => _enableOABCenterToolbarsOnPartsPickerCollapse.Value = value;
+        }
+
+        public void SetUpConfig()
+        {
+            _enableOABPartsPickerCollapseToggle = PluginConfig.Bind(
+                _OABSectionString,  // Section name
+                "Enable toggle button to collapse the parts picker drawer",  // Configuration key
+                true,  // Default value
+                "A toggle button is added that will expand and collapse the parts picker drawer.");  // Description
+            Logger.LogDebug(_enableOABPartsPickerCollapseToggle.Value);
+
+            _enableOABCenterToolbarsOnPartsPickerCollapse = PluginConfig.Bind(
+                _OABSectionString,  // Section name
+                "TestHeader",  // Configuration key
+                true,  // Default value
+                "This is just a test config option.");  // Description
+            Logger.LogDebug(_enableOABCenterToolbarsOnPartsPickerCollapse.Value);
+        }
+
+        public void AddEntryWithAttribute<T>(ConfigEntry<T> entry)
+        {
+            bool isComparable = entry.Value is System.IComparable;
+            bool isEquatable = entry.Value is System.IEquatable<T>;
+            System.Attribute[] attributes = System.Attribute.GetCustomAttributes(entry.GetType());
+            AcceptableValueBase acceptableValues = null;
+            foreach (System.Attribute attr in attributes)
+            {
+                if (attr is ConfigEntryInfoAttribute<T>)
+                {
+
+                }
+
+                if (isComparable)
+                {
+                    System.Type rangeType = typeof(T);
+                    acceptableValues = GetEntryRangeFromAttribute(attr, rangeType);
+                }
+
+                if (isEquatable)
+                {
+
+                }
+            }
+        }
+        public AcceptableValueBase GetEntryRangeFromAttribute(System.Attribute attribute, System.Type type)
+        {
+            AcceptableValueBase valueRange = null;
+            System.Type test = typeof(AcceptableConfigRangeAttribute<int>);
+            test.GetType();
+            if (attribute is AcceptableConfigRangeAttribute<bool>)
+            {
+                AcceptableConfigRangeAttribute<T> rangeAttr = attribute as AcceptableConfigRangeAttribute<T>;
+                valueRange = rangeAttr.GetRange();
+            }
+            return valueRange;
+        }
+
+        public AcceptableValueBase GetEntryListFromAttribute<T>(System.Attribute attribute) where T : System.IEquatable<T>
+        {
+            AcceptableValueBase valueList = null;
+            if (attribute is AcceptableConfigListAttribute<T>)
+            {
+                AcceptableConfigListAttribute<T> listAttr = attribute as AcceptableConfigListAttribute<T>;
+                valueList = listAttr.GetList();
+            }
+            return valueList;
+        }
+
+        const string _OABSectionString = "Vehicle Assembly Building (VAB/OAB)";
+        [ConfigEntryInfo<bool>(
+            _OABSectionString,
+            "Enable toggle button to collapse the parts picker drawer",
+            true,
+            Description = "A toggle button is added that will expand and collapse the parts picker drawer.")]
+        private ConfigEntry<bool> _enableOABPartsPickerCollapseToggle;
+
+        [ConfigEntryInfo<bool>(
+            _OABSectionString,
+            "Keep vehicle toolbars centered in work area when parts picker drawer is collapsed",
+            true,
+            Description = "When the parts picker drawer is collapsed, this setting will automatically position the vehicle editing toolbars in the center of the working area.")]
+        private ConfigEntry<bool> _enableOABCenterToolbarsOnPartsPickerCollapse;
+
+        [ConfigEntryInfo<string>(
+            _OABSectionString,
+            "Tests a list of string options",
+            "Default",
+            Description = "This hopefully has a list of available string values.")]
+        [AcceptableConfigList<string>("Default", "First", "Second", "Third")]
+        private ConfigEntry<string> _testStringList;
+
+    }
+}

--- a/alternative_ui/AUIConfigurationSettings.cs
+++ b/alternative_ui/AUIConfigurationSettings.cs
@@ -1,10 +1,55 @@
 using BepInEx.Configuration;
 using KSP.Game;
+using System;
 
 namespace AUI
 {
+    public class SuperEntry<T>
+    {
+        public string Section = "General";
+        public string Key = "";
+        public T Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                if (Entry != null)
+                {
+                    Entry.Value = value;
+                }
+            }
+        }
+        public string Description = "";
+        public AcceptableValueBase AcceptableValues = null;
+        public ConfigEntry<T> Entry
+        {
+            get;
+            protected set;
+        } = null;
+
+        public SuperEntry(string section, string key, T value, string description, AcceptableValueBase acceptableValues = null)
+        {
+            Section = section;
+            Key = key;
+            Value = value;
+            Description = description;
+            AcceptableValues = acceptableValues;
+        }
+
+        public void BindMe(ConfigFile config)
+        {
+            ConfigDefinition entryDef = new ConfigDefinition(Section, Key);
+            ConfigDescription entryDesc = new ConfigDescription(Description, AcceptableValues);
+            Entry = config.Bind(entryDef, Value, entryDesc);
+        }
+
+        private T _value;
+    }
+
     /// <summary>Represents basic info for a ConfigEntry.</summary>
-    public class ConfigEntryInfoAttribute<T> : System.Attribute
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class ConfigEntryInfoAttribute<T> : Attribute
     {
         public string Section;
         public string Key;
@@ -20,32 +65,51 @@ namespace AUI
     }
 
     // TODO Create an interface that has a common method to get an AcceptableValueBase from both types of attributes.
-    public class AcceptableConfigRangeAttribute<T> : System.Attribute where T : System.IComparable
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = true)]
+    public abstract class AcceptableValueAttribute : Attribute
+    {
+        public abstract AcceptableValueBase GetAcceptableValues();
+    }
+
+    public class AcceptableConfigRangeAttribute<T> : AcceptableValueAttribute where T : IComparable
     {
         private AcceptableValueRange<T> _range;
+
         public AcceptableConfigRangeAttribute(T min, T max)
         {
             _range = new AcceptableValueRange<T>(min, max);
         }
 
-        public AcceptableValueRange<T> GetRange()
+        public override AcceptableValueBase GetAcceptableValues()
         {
             return _range;
         }
     }
 
-    public class AcceptableConfigListAttribute<T> : System.Attribute where T : System.IEquatable<T>
+    public class AcceptableConfigListAttribute<T> : AcceptableValueAttribute where T : IEquatable<T>
     {
         private AcceptableValueList<T> _list;
+
         public AcceptableConfigListAttribute(params T[] acceptableValues)
         {
             _list = new AcceptableValueList<T>(acceptableValues);
         }
 
-        public AcceptableValueList<T> GetList()
+        public override AcceptableValueBase GetAcceptableValues()
         {
             return _list;
         }
+    }
+
+    [Serializable]
+    public class InvalidConfigurationAttributesException : Exception
+    {
+        public InvalidConfigurationAttributesException() { }
+        public InvalidConfigurationAttributesException(string message) : base(message) { }
+        public InvalidConfigurationAttributesException(string message, Exception inner) : base(message, inner) { }
+        protected InvalidConfigurationAttributesException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 
     public class AUIConfigurationSettings : KerbalMonoBehaviour
@@ -64,70 +128,93 @@ namespace AUI
             set => _enableOABCenterToolbarsOnPartsPickerCollapse.Value = value;
         }
 
+        public void AddSuperEntry<T>(SuperEntry<T> superEntry)
+        {
+            superEntry.BindMe(PluginConfig);
+        }
+
+        // public void AddEntryWithAttribute<T>(SuperEntry<T> superEntry)
+        // {
+        //     Logger.LogError($"AddEntryWithAttribute: Start ({superEntry.ToString()})");
+        //     // Attribute[] attributes = Attribute.GetCustomAttributes(superEntry.GetType());
+        //     ConfigEntryInfoAttribute<T>[] attributes = (ConfigEntryInfoAttribute<T>[])superEntry.GetType().GetCustomAttributes(typeof(ConfigEntryInfoAttribute<T>), false);
+        //     Logger.LogWarning($"AddEntryWithAttribute: Num ConfigEntryInfo Attributes: {attributes.Count()}");
+
+        //     ConfigEntryInfoAttribute<T> entryInfo = null;
+        //     AcceptableValueBase acceptableValues = null;
+
+        //     foreach (Attribute attr in attributes)
+        //     {
+        //         Logger.LogWarning($"AddEntryWithAttribute:   Attribute ({attr})");
+        //         if (attr is ConfigEntryInfoAttribute<T>)
+        //         {
+        //             if (entryInfo == null)
+        //             {
+        //                 entryInfo = attr as ConfigEntryInfoAttribute<T>;
+        //                 Logger.LogInfo($"AddEntryWithAttribute:     attribute is ConfigEntryInfoAttribute ({entryInfo})");
+        //             }
+        //             else
+        //             {
+        //                 throw new InvalidConfigurationAttributesException("Multiple ConfigEntryInfo attributes detected. Only one ConfigEntryInfo attribute is allowed per ConfigEntry.");
+        //             }
+        //         }
+
+        //         if (attr is AcceptableValueAttribute)
+        //         {
+        //             if (acceptableValues == null)
+        //             {
+        //                 acceptableValues = (attr as AcceptableValueAttribute).GetAcceptableValues();
+        //                 Logger.LogInfo($"AddEntryWithAttribute:     attribute is AcceptableValueAttribute ({acceptableValues})");
+        //             }
+        //             else
+        //             {
+        //                 throw new InvalidConfigurationAttributesException("Multiple AcceptableValue attributes detected. Only one AcceptableValue attribute is allowed per ConfigEntry.");
+        //             }
+        //         }
+        //     }
+
+        //     if (entryInfo == null)
+        //     {
+        //         if (acceptableValues != null)
+        //         {
+        //             throw new InvalidConfigurationAttributesException("Detected a AcceptableValue attribute without a ConfigEntryInfo attribute. A ConfigEntryInfo attribute is required in order to use an AcceptableValue attribute.");
+        //         }
+        //         else
+        //         {
+        //             // No config-related attribute found. This entry must be manually bound later.
+        //             Logger.LogWarning($"AddEntryWithAttribute<T>: Was provided with a ConfigEntry item without a ConfigEntryInfo attribute set! Make sure that this is intentional and that the ConfigEntry item will be bound to the ConfigFile at a later point! {superEntry.ToString()}");
+        //         }
+        //     }
+        //     else
+        //     {
+        //         // A config info attribute is attached to this entry. Automatically bind it to the config file.
+        //         ConfigDefinition entryDef = new ConfigDefinition(entryInfo.Section, entryInfo.Key);
+        //         ConfigDescription entryDesc = new ConfigDescription(entryInfo.Description, acceptableValues);
+        //         superEntry.Entry = PluginConfig.Bind(entryDef, entryInfo.Value, entryDesc);
+        //         Logger.LogInfo($"AddEntryWithAttribute:     Binding to config file ({superEntry.Entry})");
+        //     }
+        //     Logger.LogWarning($"AddEntryWithAttribute: End");
+        // }
+
         public void SetUpConfig()
         {
-            _enableOABPartsPickerCollapseToggle = PluginConfig.Bind(
-                _OABSectionString,  // Section name
-                "Enable toggle button to collapse the parts picker drawer",  // Configuration key
-                true,  // Default value
-                "A toggle button is added that will expand and collapse the parts picker drawer.");  // Description
-            Logger.LogDebug(_enableOABPartsPickerCollapseToggle.Value);
+            Logger.LogInfo("Setting up AUI configuration settings.");
+            // _enableOABPartsPickerCollapseToggle = PluginConfig.Bind(
+            //     _OABSectionString,  // Section name
+            //     "Enable toggle button to collapse the parts picker drawer",  // Configuration key
+            //     true,  // Default value
+            //     "A toggle button is added that will expand and collapse the parts picker drawer.");  // Description
+            // Logger.LogDebug(_enableOABPartsPickerCollapseToggle.Value);
 
-            _enableOABCenterToolbarsOnPartsPickerCollapse = PluginConfig.Bind(
-                _OABSectionString,  // Section name
-                "TestHeader",  // Configuration key
-                true,  // Default value
-                "This is just a test config option.");  // Description
-            Logger.LogDebug(_enableOABCenterToolbarsOnPartsPickerCollapse.Value);
-        }
-
-        public void AddEntryWithAttribute<T>(ConfigEntry<T> entry)
-        {
-            bool isComparable = entry.Value is System.IComparable;
-            bool isEquatable = entry.Value is System.IEquatable<T>;
-            System.Attribute[] attributes = System.Attribute.GetCustomAttributes(entry.GetType());
-            AcceptableValueBase acceptableValues = null;
-            foreach (System.Attribute attr in attributes)
-            {
-                if (attr is ConfigEntryInfoAttribute<T>)
-                {
-
-                }
-
-                if (isComparable)
-                {
-                    System.Type rangeType = typeof(T);
-                    acceptableValues = GetEntryRangeFromAttribute(attr, rangeType);
-                }
-
-                if (isEquatable)
-                {
-
-                }
-            }
-        }
-        public AcceptableValueBase GetEntryRangeFromAttribute(System.Attribute attribute, System.Type type)
-        {
-            AcceptableValueBase valueRange = null;
-            System.Type test = typeof(AcceptableConfigRangeAttribute<int>);
-            test.GetType();
-            if (attribute is AcceptableConfigRangeAttribute<bool>)
-            {
-                AcceptableConfigRangeAttribute<T> rangeAttr = attribute as AcceptableConfigRangeAttribute<T>;
-                valueRange = rangeAttr.GetRange();
-            }
-            return valueRange;
-        }
-
-        public AcceptableValueBase GetEntryListFromAttribute<T>(System.Attribute attribute) where T : System.IEquatable<T>
-        {
-            AcceptableValueBase valueList = null;
-            if (attribute is AcceptableConfigListAttribute<T>)
-            {
-                AcceptableConfigListAttribute<T> listAttr = attribute as AcceptableConfigListAttribute<T>;
-                valueList = listAttr.GetList();
-            }
-            return valueList;
+            // _enableOABCenterToolbarsOnPartsPickerCollapse = PluginConfig.Bind(
+            //     _OABSectionString,  // Section name
+            //     "TestHeader",  // Configuration key
+            //     true,  // Default value
+            //     "This is just a test config option.");  // Description
+            // Logger.LogDebug(_enableOABCenterToolbarsOnPartsPickerCollapse.Value);
+            AddSuperEntry(_enableOABPartsPickerCollapseToggle);
+            AddSuperEntry(_enableOABCenterToolbarsOnPartsPickerCollapse);
+            AddSuperEntry(_exampleTestStringList);
         }
 
         const string _OABSectionString = "Vehicle Assembly Building (VAB/OAB)";
@@ -136,22 +223,35 @@ namespace AUI
             "Enable toggle button to collapse the parts picker drawer",
             true,
             Description = "A toggle button is added that will expand and collapse the parts picker drawer.")]
-        private ConfigEntry<bool> _enableOABPartsPickerCollapseToggle;
+        private SuperEntry<bool> _enableOABPartsPickerCollapseToggle = new SuperEntry<bool>(
+            _OABSectionString,
+            "Enable toggle button to collapse the parts picker drawer",
+            true,
+            "A toggle button is added that will expand and collapse the parts picker drawer.");
 
         [ConfigEntryInfo<bool>(
             _OABSectionString,
             "Keep vehicle toolbars centered in work area when parts picker drawer is collapsed",
             true,
             Description = "When the parts picker drawer is collapsed, this setting will automatically position the vehicle editing toolbars in the center of the working area.")]
-        private ConfigEntry<bool> _enableOABCenterToolbarsOnPartsPickerCollapse;
+        private SuperEntry<bool> _enableOABCenterToolbarsOnPartsPickerCollapse = new SuperEntry<bool>(
+            _OABSectionString,
+            "Keep vehicle toolbars centered in work area when parts picker drawer is collapsed",
+            true,
+            "When the parts picker drawer is collapsed, this setting will automatically position the vehicle editing toolbars in the center of the working area.");
 
         [ConfigEntryInfo<string>(
-            _OABSectionString,
+            "Debug Settings",
             "Tests a list of string options",
             "Default",
             Description = "This hopefully has a list of available string values.")]
         [AcceptableConfigList<string>("Default", "First", "Second", "Third")]
-        private ConfigEntry<string> _testStringList;
+        public SuperEntry<string> _exampleTestStringList = new SuperEntry<string>(
+            "Debug Settings",
+            "Tests a list of string options",
+            "Default",
+            "This hopefully has a list of available string values.",
+            new AcceptableValueList<string>("Default", "First", "Second", "Third"));
 
     }
 }

--- a/alternative_ui/AlternativeUIPlugin.cs
+++ b/alternative_ui/AlternativeUIPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using BepInEx;
 using BepInEx.Configuration;
 using KSP.Messages;
@@ -63,7 +63,7 @@ namespace AUI
         private void Awake()
         {
             ConfigSettings = new AUIConfigurationSettings();
-            ConfigSettings.PluginConfig = Config;  // Delegate plugin settings to other class.
+            ConfigSettings.PluginConfig = Config;  // Delegate plugin settings to another class.
             ConfigSettings.Logger = Logger;
             ConfigSettings.SetUpConfig();
         }

--- a/alternative_ui/AlternativeUIPlugin.cs
+++ b/alternative_ui/AlternativeUIPlugin.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using BepInEx;
-using BepInEx.Configuration;
 using KSP.Messages;
 using SpaceWarp;
 using SpaceWarp.API.Mods;

--- a/alternative_ui/AlternativeUIPlugin.cs
+++ b/alternative_ui/AlternativeUIPlugin.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BepInEx;
+using BepInEx.Configuration;
 using KSP.Messages;
 using SpaceWarp;
 using SpaceWarp.API.Mods;
@@ -7,10 +8,11 @@ using UnityEngine;
 
 namespace AUI
 {
-    [BepInPlugin("com.arcticninja73.AUI", "AlternativeUI (AUI)", "0.1.0")]
+    [BepInPlugin("com.kkaja123." + MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     [BepInDependency(SpaceWarpPlugin.ModGuid, SpaceWarpPlugin.ModVer)]
     public class AlternativeUIPlugin : BaseSpaceWarpPlugin
     {
+        public AUIConfigurationSettings ConfigSettings;
         public bool EnablePartsPickerToggleButton
         {
             get => _partsPickerToggleButtonIsEnabled;
@@ -58,6 +60,13 @@ namespace AUI
             protected set => _collapsedOABToolbarsUIConfiguration = value;
         }
 
+        private void Awake()
+        {
+            ConfigSettings = new AUIConfigurationSettings();
+            ConfigSettings.PluginConfig = Config;  // Delegate plugin settings to other class.
+            ConfigSettings.Logger = Logger;
+            ConfigSettings.SetUpConfig();
+        }
 
         public override void OnInitialized()
         {
@@ -369,6 +378,7 @@ namespace AUI
             pixelDeltaX = pixelDeltaX * 2;  // Return to base value
             CollapsedOABToolbarsUIConfiguration.RootWidget.sizeDelta = DefaultOABToolbarsUIConfiguration.RootWidget.sizeDelta with { x = pixelDeltaX };  // X size gets the left side of the widget near to the right side of parts picker.
         }
+
 
         protected bool _uiConfigurationsAreInitialized = false;
 

--- a/alternative_ui/alternative_ui.csproj
+++ b/alternative_ui/alternative_ui.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>AUI</AssemblyName>
-    <Description>AlternativeUI for KSP 2</Description>
+    <Description>AlternativeUI (AUI)</Description>
+    <Product>AlternativeUI (AUI)</Product>
     <Version>0.1.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Add `AUIConfigurationSettings`, which acts as a manager for AUI's configuration settings. `AlternativeUIPlugin` still handles the behavior, but it will get the settings from a stored `AUIConfigurationSettings` to know the user's settings.

With this addition, I've added an option for not auto-centering the OAB toolbars when collapsing the parts picker. By default, it will auto-center the toolbars.

Addresses #3 and #16.